### PR TITLE
FileDownloadNetworkPolicyException Should Trigger Error Callback

### DIFF
--- a/library/src/main/java/com/liulishuo/filedownloader/download/DownloadLaunchRunnable.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/download/DownloadLaunchRunnable.java
@@ -269,7 +269,7 @@ public class DownloadLaunchRunnable implements Runnable, ProcessCallback {
                         }
                     }
 
-                } catch (IOException | IllegalAccessException | InterruptedException | IllegalArgumentException e) {
+                } catch (IOException | IllegalAccessException | InterruptedException | IllegalArgumentException | FileDownloadNetworkPolicyException e) {
                     if (isRetry(e)) {
                         onRetry(e, 0);
                         continue;

--- a/library/src/main/java/com/liulishuo/filedownloader/download/DownloadLaunchRunnable.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/download/DownloadLaunchRunnable.java
@@ -269,7 +269,7 @@ public class DownloadLaunchRunnable implements Runnable, ProcessCallback {
                         }
                     }
 
-                } catch (IOException | IllegalAccessException | InterruptedException | IllegalArgumentException | FileDownloadNetworkPolicyException e) {
+                } catch (IOException | IllegalAccessException | InterruptedException | IllegalArgumentException | FileDownloadGiveUpRetryException e) {
                     if (isRetry(e)) {
                         onRetry(e, 0);
                         continue;


### PR DESCRIPTION
Right now, the following exception would be triggered when attempting to download in cellular after setWifiRequired(true) is called:
```
 com.liulishuo.filedownloader.exception.FileDownloadNetworkPolicyException: Only allows downloading this task on the wifi network type
at com.liulishuo.filedownloader.download.DownloadLaunchRunnable.checkupBeforeConnect(DownloadLaunchRunnable.java:690)
at com.liulishuo.filedownloader.download.DownloadLaunchRunnable.run(DownloadLaunchRunnable.java:217)
at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
at java.lang.Thread.run(Thread.java:761)
```
This is not very helpful because the exception can't be caught and would just crash the app. It is much more helpful to trigger an error callback instead of crashing.