### PR TITLE
1.尝试修复由于DownloadRunnable在FetchDataTask中出现异常时，未将全部DownloadLaunchRunnal…

### DIFF
--- a/library/src/main/java/com/liulishuo/filedownloader/IThreadPoolMonitor.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/IThreadPoolMonitor.java
@@ -26,4 +26,6 @@ public interface IThreadPoolMonitor {
     boolean isDownloading(FileDownloadModel model);
 
     int findRunningTaskIdBySameTempPath(String tempFilePath, int excludeId);
+
+    void deleteThread(int id);
 }

--- a/library/src/main/java/com/liulishuo/filedownloader/download/DownloadRunnable.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/download/DownloadRunnable.java
@@ -60,6 +60,10 @@ public class DownloadRunnable implements Runnable {
         if (fetchDataTask != null) fetchDataTask.pause();
     }
 
+    public void stopTask(){
+        fetchDataTask.stop();
+    }
+
     public void discard() {
         pause();
     }
@@ -117,6 +121,7 @@ public class DownloadRunnable implements Runnable {
                 }
                 break;
             } catch (IllegalAccessException | IOException | FileDownloadGiveUpRetryException | IllegalArgumentException e) {
+
                 if (callback.isRetry(e)) {
                     if (!isConnected) {
                         callback.onRetry(e, 0);

--- a/library/src/main/java/com/liulishuo/filedownloader/download/FetchDataTask.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/download/FetchDataTask.java
@@ -77,6 +77,11 @@ public class FetchDataTask {
         contentLength = connectionProfile.contentLength;
     }
 
+    private boolean tag = true;
+    public void stop(){
+        tag = false;
+    }
+
     public void run() throws IOException, IllegalAccessException, IllegalArgumentException,
             FileDownloadGiveUpRetryException {
 
@@ -151,7 +156,7 @@ public class FetchDataTask {
                     throw new FileDownloadNetworkPolicyException();
                 }
 
-            } while (true);
+            } while (tag);
 
         } finally {
 

--- a/library/src/main/java/com/liulishuo/filedownloader/services/FileDownloadManager.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/services/FileDownloadManager.java
@@ -317,6 +317,11 @@ class FileDownloadManager implements IThreadPoolMonitor {
         return mThreadPool.findRunningTaskIdBySameTempPath(tempFilePath, excludeId);
     }
 
+    @Override
+    public void deleteThread(int id) {
+        mThreadPool.cancel(id);
+    }
+
     public boolean clearTaskData(int id) {
         if (id == 0) {
             FileDownloadLog.w(this, "The task[%d] id is invalid, can't clear it.", id);


### PR DESCRIPTION
1.尝试修复由于DownloadRunnable在FetchDataTask中出现异常时，未将全部DownloadLaunchRunnable创建的全部线程关闭的问题。原代码的意图是忽略该异常并重新再DownloadLaunchRunnable中重新创建，经过测试后发现，该异常会一直存在，因此没有意义，并且最终会导致socketTimeout异常，具体原因不明。

2.尝试修复由于DownloadLaunchRunnable因为子线程上抛异常时退出，handlerThread死亡后无法回调error，导致DownloadTask状态异常而重新下载的问题。原代码中因为pause的flag而忽略异常的判断会导致异常无法正确回调，故增加判断，保证onerror能正确回调并回收线程。

具体代码可能有些不合适，还请大佬验证。修改后的代码经过测试，目前可以解决在恶劣网络状况下会频繁重新下载的问题。