### PR TITLE
fix: cannot get content length during download connections

### DIFF
--- a/library/src/main/java/com/liulishuo/filedownloader/download/DownloadLaunchRunnable.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/download/DownloadLaunchRunnable.java
@@ -537,7 +537,7 @@ public class DownloadLaunchRunnable implements Runnable, ProcessCallback {
 
         redirectedUrl = connectTask.getFinalRedirectedUrl();
         if (acceptPartial || onlyFromBeginning) {
-            final long totalLength = FileDownloadUtils.findInstanceLengthForTrial(id, connection);
+            final long totalLength = FileDownloadUtils.findInstanceLengthForTrial(connection);
 
             // update model
             String fileName = null;

--- a/library/src/main/java/com/liulishuo/filedownloader/download/FetchDataTask.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/download/FetchDataTask.java
@@ -82,7 +82,10 @@ public class FetchDataTask {
 
         if (paused) return;
 
-        final long contentLength = FileDownloadUtils.findContentLength(connectionIndex, connection);
+        long contentLength = FileDownloadUtils.findContentLength(connectionIndex, connection);
+        if (contentLength == TOTAL_VALUE_IN_CHUNKED_RESOURCE) {
+            contentLength = FileDownloadUtils.findContentLengthFromContentRange(connection);
+        }
         if (contentLength == 0) {
             throw new FileDownloadGiveUpRetryException(FileDownloadUtils.
                     formatString(

--- a/library/src/main/java/com/liulishuo/filedownloader/util/FileDownloadUtils.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/util/FileDownloadUtils.java
@@ -578,6 +578,7 @@ public class FileDownloadUtils {
     public static long findContentLength(final int id, FileDownloadConnection connection) {
         long contentLength = FileDownloadUtils
                 .convertContentLengthString(connection.getResponseHeaderField("Content-Length"));
+        if (contentLength < 0) contentLength = findInstanceLengthFromContentRange(connection);
         final String transferEncoding = connection.getResponseHeaderField("Transfer-Encoding");
 
         if (contentLength < 0) {

--- a/library/src/test/java/com/liulishuo/filedownloader/util/FileDownloadUtilsTest.java
+++ b/library/src/test/java/com/liulishuo/filedownloader/util/FileDownloadUtilsTest.java
@@ -35,4 +35,28 @@ public class FileDownloadUtilsTest {
         assertThat(filename).isEqualTo("genome.jpeg");
     }
 
+    @Test
+    public void parseContentLengthFromContentRange_withNullContentRange() {
+        long length = FileDownloadUtils.parseContentLengthFromContentRange(null);
+        assertThat(length).isEqualTo(-1);
+    }
+
+    @Test
+    public void parseContentLengthFromContentRange_withEmptyContentRange() {
+        long length = FileDownloadUtils.parseContentLengthFromContentRange("");
+        assertThat(length).isEqualTo(-1);
+    }
+
+    @Test
+    public void parseContentLengthFromContentRange_withStartToEndRange() {
+        long length = FileDownloadUtils.parseContentLengthFromContentRange("bytes 25086300-37629450/37629451");
+        assertThat(length).isEqualTo(12543151);
+    }
+
+    @Test
+    public void parseContentLengthFromContentRange_withUnavailableContentRange() {
+        long length = FileDownloadUtils.parseContentLengthFromContentRange("bytes 0-/37629451");
+        assertThat(length).isEqualTo(-1);
+    }
+
 }

--- a/library/src/test/java/com/liulishuo/filedownloader/util/FileDownloadUtilsTest.java
+++ b/library/src/test/java/com/liulishuo/filedownloader/util/FileDownloadUtilsTest.java
@@ -49,7 +49,8 @@ public class FileDownloadUtilsTest {
 
     @Test
     public void parseContentLengthFromContentRange_withStartToEndRange() {
-        long length = FileDownloadUtils.parseContentLengthFromContentRange("bytes 25086300-37629450/37629451");
+        long length = FileDownloadUtils
+                .parseContentLengthFromContentRange("bytes 25086300-37629450/37629451");
         assertThat(length).isEqualTo(12543151);
     }
 


### PR DESCRIPTION
should get content length from Content-Range if there is no Content-Length in the response header during download connections

close #967