### PR TITLE
修复 #1131 content-range和request range不一致造成的下载失败(服务器可能会不接受大块的请求)

### DIFF
--- a/library/src/main/java/com/liulishuo/filedownloader/download/ConnectionProfile.java
+++ b/library/src/main/java/com/liulishuo/filedownloader/download/ConnectionProfile.java
@@ -79,7 +79,7 @@ public class ConnectionProfile {
         }
 
         final String range;
-        if (endOffset == RANGE_INFINITE) {
+        if (endOffset == RANGE_INFINITE || endOffset == 0) {
             range = FileDownloadUtils.formatString("bytes=%d-", currentOffset);
         } else {
             range = FileDownloadUtils


### PR DESCRIPTION
[修改说明]第一次发送range为bytes=0-的请求时，服务端返回的content-length可能不是文件的总大小，可能是分块的大小，所以解析content-range获取文件的总大小，记为total-length。
然后对比total-length与content-length的大小，如果不一致，服务器返回的则是分块的大小。然后在计算分块的count时，使用total-length/content-length。
[自测情况]已自测，https://cbabae.link.yunpan.360.cn/lk/surl_ydwseCJfKEA#/-0 正常下载薛之谦-我终于成了别人的女人
[影响功能]多线程分块下载